### PR TITLE
Added MetadataPopulator for radius mfa

### DIFF
--- a/cas-server-support-radius-mfa/src/main/java/org/apereo/cas/adaptors/radius/RadiusAuthenticationMetaDataPopulator.java
+++ b/cas-server-support-radius-mfa/src/main/java/org/apereo/cas/adaptors/radius/RadiusAuthenticationMetaDataPopulator.java
@@ -1,0 +1,50 @@
+package org.apereo.cas.adaptors.radius;
+
+import org.apereo.cas.authentication.AuthenticationBuilder;
+import org.apereo.cas.authentication.AuthenticationHandler;
+import org.apereo.cas.authentication.AuthenticationManager;
+import org.apereo.cas.authentication.AuthenticationMetaDataPopulator;
+import org.apereo.cas.authentication.Credential;
+import org.apereo.cas.services.MultifactorAuthenticationProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.stereotype.Component;
+
+/**
+ * This is {@link RadiusAuthenticationMetaDataPopulator} which inserts the
+ * radius MFA provider id into the final authentication object.
+ *
+ * @author Nagai Takayuki
+ * @since 5.0.0
+ */
+@RefreshScope
+@Component("radiusAuthenticationMetaDataPopulator")
+public class RadiusAuthenticationMetaDataPopulator implements AuthenticationMetaDataPopulator {
+
+    @Value("${cas.mfa.authn.ctx.attribute:authnContextClass}")
+    private String authenticationContextAttribute;
+
+    @Autowired
+    @Qualifier("radiusTokenAuthenticationHandler")
+    private AuthenticationHandler authenticationHandler;
+
+
+    @Autowired
+    @Qualifier("radiusAuthenticationProvider")
+    private MultifactorAuthenticationProvider provider;
+
+    @Override
+    public void populateAttributes(final AuthenticationBuilder builder, final Credential credential) {
+        if (builder.hasAttribute(AuthenticationManager.AUTHENTICATION_METHOD_ATTRIBUTE,
+                obj -> obj.toString().equals(this.authenticationHandler.getName()))) {
+            builder.mergeAttribute(this.authenticationContextAttribute, this.provider.getId());
+        }
+    }
+
+    @Override
+    public boolean supports(final Credential credential) {
+        return this.authenticationHandler.supports(credential);
+    }
+}


### PR DESCRIPTION
Issue:
serviceValidate phase of radius-mfa fails because metadata populator for radius-mfa is not implemented.

Change:
I added a RadiusAuthenticationMetaDataPopulator class  which inserts the radius MFA provider id into the final authentication object.

